### PR TITLE
Prohibit reloading of all defined Tasks when livereload starts

### DIFF
--- a/livereload/task.py
+++ b/livereload/task.py
@@ -61,12 +61,13 @@ class Task(object):
             modified = int(os.stat(path).st_mtime)
 
             if path in cls._modified_times and \
-               cls._modified_times[path] == modified:
-                return False
+               cls._modified_times[path] != modified:
+                logging.info('file changed: %s' % path)
+                cls._modified_times[path] = modified
+                return True
 
             cls._modified_times[path] = modified
-            logging.info('file changed: %s' % path)
-            return True
+            return False
 
         def is_folder_changed(path):
             for root, dirs, files in os.walk(path):


### PR DESCRIPTION
Previously every file matching a `Task` definitions was causing the browser to reload when `livereload` is started. In other words if your tasks are watching 20 files, your browser will go nuts of reloading (20 times) when you start `livereload`.

The fix does not reload when a file's path is not yet in `cls._modified_times` and reloading otherwise if the stored timestamp and the `modified` are not matching. 
