### PR TITLE
add support for rst compilation

### DIFF
--- a/livereload/compiler.py
+++ b/livereload/compiler.py
@@ -85,7 +85,7 @@ class _CommandCompiler(BaseCompiler):
     command_options = ''
 
     def _get_code(self):
-        cmd = [self.command]# self.command_options, self.path]
+        cmd = [self.command]
         if self.command_options:
             cmd.append(self.command_options)
         cmd.append(self.path)
@@ -155,8 +155,10 @@ def slimmer(path, output, mode='w'):
         return
     return functools.partial(_compile, path, output, mode)
 
+
 class RstCompiler(_CommandCompiler):
     command = 'rst2html.py'
+
 
 def rstc(path, output, mode='w'):
     def _compile(path, output, mode):
@@ -166,4 +168,3 @@ def rstc(path, output, mode='w'):
         else:
             c.write(output)
     return functools.partial(_compile, path, output, mode)
-

--- a/livereload/task.py
+++ b/livereload/task.py
@@ -60,8 +60,8 @@ class Task(object):
 
             modified = int(os.stat(path).st_mtime)
 
-            if path in cls._modified_times and \
-               cls._modified_times[path] != modified:
+            if (path in cls._modified_times and
+                    cls._modified_times[path] != modified):
                 logging.info('file changed: %s' % path)
                 cls._modified_times[path] = modified
                 return True


### PR DESCRIPTION
restructuredText can also get some love.

I'm using this for writing class notes or otherwise live previewing my restructured text code. Works really well. :) (PS: With the :math: directive, means you can also live-preview LaTeX code in the browser (default is with mathjax. Woot!)

Didn't do egregious amounts of testing, but seems to be working fine. Successfully prints out errors when rst2html.py fails.

Example:

```
    raise Exception(stderr)
Exception: test.rst:5: (WARNING/2) Title underline too short.

Hellofasldkfjskfj
------
```

---

The Guardfile I'm currently using looks like the following:

```
#!/usr/bin/env python
from livereload.task import Task
from livereload.compiler import rstc

Task.add('test.rst', rstc('test.rst', 'test.html'))
```

However, I would love to get glob support going for arbitrary file compilation. But it seems like the framework doesn't pass along file names to the compilation step. Maybe this is something that should be happening?
