### PR TITLE
Add CoffeeScript Support

### DIFF
--- a/livereload/compiler.py
+++ b/livereload/compiler.py
@@ -156,3 +156,12 @@ def rstc(path, output, mode='w'):
     _compile = CommandCompiler(path)
     _compile.init_command('rst2html.py')
     return functools.partial(_compile, output, mode)
+
+
+def coffee(path, output, mode='w'):
+    _compile = CommandCompiler(path)
+    f = open(path)
+    code = f.read()
+    f.close()
+    _compile.init_command('coffee --compile --stdio', code)
+    return functools.partial(_compile, output, mode)


### PR DESCRIPTION
Compile coffeescript files similar to how you compile less or other compiled sources.

I added a class called `_StdinCompiler` which is very similar to `_CommandCompiler`, but gets files in and out via stdio instead of passing file names as arguments. This is because `coffee` does not let you choose the output file name when compiling (it just swaps *.coffee for *.js). Getting sources in and out via stdin mode allows us to write the files with python using arbitrary file names, so we can keep the same `Task(file, compiler(in, out))` pattern in the `Guardfile`.

`_StdinCompiler` is nearly identical to `_CommandCompiler`, but it 1) doesn't append a filename to the end of the command, 2) uses `Popen` with `stdin=PIPE` and 3) pipes in the input file when it calls `communicate()`. Maybe setting some kind of switch and three if statements in the body would yield lower code duplication, but it felt to hacky when I was writing it that way. I'm interested in feedback on my approach!

edit: re-written to fit in the refactored `compiler.py`. The new version just adds a coffee function.
