### PR TITLE
--directory option, allowing serving a different directory tree

### DIFF
--- a/livereload/cli.py
+++ b/livereload/cli.py
@@ -7,21 +7,22 @@ from livereload import server
 cmd = """Python LiveReload
 
 Usage:
-    livereload [-p <port>|--port=<port>]
+    livereload [-p <port>|--port=<port>] [-d <directory>|--directory=<directory>]
 
 Options:
     -h --help                       show this screen
     -p <port> --port=<port>         specify a server port, default is 35729
-
+    -d <root> --directory=<root>    specify a web root, default is '.'
 """
 
 
 def main():
     args = docopt(cmd)
     port = args.get('--port')
+    root = args.get('--directory')
     if port:
         port = int(port)
     else:
         port = 35729
 
-    server.start(port)
+    server.start(port, root)

--- a/livereload/server.py
+++ b/livereload/server.py
@@ -19,6 +19,7 @@ from livereload.task import Task
 
 
 PORT = 35729
+ROOT = '.'
 LIVERELOAD = os.path.join(
     os.path.abspath(os.path.dirname(__file__)),
     'livereload.js',
@@ -109,8 +110,9 @@ class LiveReloadHandler(websocket.WebSocketHandler):
 
 
 class IndexHandler(RequestHandler):
+
     def get(self, path='/'):
-        abspath = os.path.join(os.path.abspath('.'), path.lstrip('/'))
+        abspath = os.path.join(os.path.abspath(ROOT), path.lstrip('/'))
         mime_type, encoding = mimetypes.guess_type(abspath)
         if not mime_type:
             mime_type = 'text/html'
@@ -178,14 +180,18 @@ handlers = [
 ]
 
 
-def start(port=35729):
+def start(port=35729, root='.'):
     global PORT
     PORT = port
+    global ROOT
+    if root is None:
+        root = '.'
+    ROOT = root
     logging.getLogger().setLevel(logging.INFO)
     enable_pretty_logging()
     app = Application(handlers=handlers)
     app.listen(port)
-    print('Start service at  127.0.0.1:%s' % port)
+    print('Serving path %s on 127.0.0.1:%s' % (root, port))
     ioloop.IOLoop.instance().start()
 
 


### PR DESCRIPTION
I'm using [sphinx](http://sphinx-doc.org), which tends to structure things like:

```
mydoc/
   Makefile
   build/
      html/
   source/
      index.rst
      otherdir/
          index.rst
```

so I want to watch the source/ directory, run a command and serve up build/html/. Also, it makes more sense to keep the `Guardfile` next to the `Makefile`.

This simple patch allows me to run

```
    livereload -d build/html
```

with a very simple `Guardfile`

```
@functools.partial
def build_sphinx():
    import subprocess
    subprocess.call(['make', 'html'])
Task.add('source/', build_sphinx)
```
