### PR TITLE
Fix injection where there is stuff on the same line as </head>

### DIFF
--- a/livereload/server.py
+++ b/livereload/server.py
@@ -142,14 +142,14 @@ class IndexHandler(RequestHandler):
         if os.path.exists(filepath):
             for line in open(filepath):
                 if '</head>' in line:
-		    before, after = line.split("</head>")
-		    # If there is stuff in front of </head>, write it before
-		    # injecting the script
-		    self.write(before)
+                    before, after = line.split("</head>")
+                    # If there is stuff in front of </head>, write it before
+                    # injecting the script
+                    self.write(before)
                     self.inject_livereload()
-		    self.write("</head>")
-		    self.write(after)
-		else:
+                    self.write("</head>")
+                    self.write(after)
+                else:
                     self.write(line)
             return
         self.send_error(404)


### PR DESCRIPTION
Our HTML happens to contain a closing tag before `</head>` on the same line as it. Livereload injects the script and then writes out the whole line, so the script ends up inside another tag. My fix is very simple: it writes the line containing `</head>` in parts.
