### PR TITLE
Make the cli.py module runnable from shell

### DIFF
--- a/livereload/cli.py
+++ b/livereload/cli.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from docopt import docopt
-from .server import start
+from server import start
 
 
 cmd = """Python LiveReload
@@ -27,3 +27,6 @@ def main():
         port = 35729
 
     start(port, root, autoraise)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Relative imports don't work when you run the module from a different directory. You don't really need them here anyways, I think.

Thanks for your work, by the way, we're finding it really useful here :)
