### PR TITLE
Two small fixes

### DIFF
--- a/livereload/server.py
+++ b/livereload/server.py
@@ -205,7 +205,10 @@ def start(port=35729, root='.', autoraise=False):
         webbrowser.open(
             'http://127.0.0.1:%s' % port, new=2, autoraise=True
         )
-    ioloop.IOLoop.instance().start()
+    try:
+        ioloop.IOLoop.instance().start()
+    except KeyboardInterrupt:
+        print "Shutting down..."
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Return 404 when missing folders
- Quit quietly when CTRL+C is pressed instead of throwing a traceback.
