### PR TITLE
Enable live CSS changes without full page reload

### DIFF
--- a/livereload/server.py
+++ b/livereload/server.py
@@ -64,7 +64,7 @@ class LiveReloadHandler(websocket.WebSocketHandler):
 
         msg = {
             'command': 'reload',
-            'path': '*',
+            'path': Task.last_modified or '*',
             'liveCSS': True
         }
 

--- a/livereload/task.py
+++ b/livereload/task.py
@@ -28,6 +28,7 @@ IGNORE = [
 class Task(object):
     tasks = {}
     _modified_times = {}
+    last_modified = None
 
     @classmethod
     def add(cls, path, func=None):
@@ -65,6 +66,7 @@ class Task(object):
                cls._modified_times[path] != modified:
                 logging.info('file changed: %s' % path)
                 cls._modified_times[path] = modified
+                cls.last_modified = path
                 return True
 
             cls._modified_times[path] = modified


### PR DESCRIPTION
The livereload protocol already supports live CSS changes without reloading. You just have to specify the path of the modified file. 
