### PR TITLE
Added a URL endpoint to force a page reload

### DIFF
--- a/livereload/server.py
+++ b/livereload/server.py
@@ -195,11 +195,32 @@ class LiveReloadJSHandler(RequestHandler):
                 self.write(line)
 
 
+class ForceReloadHandler(RequestHandler):
+
+    def get(self):
+        logging.info('Recieved reload request')
+
+        msg = {
+            'command': 'reload',
+            'path': '*',
+            'liveCSS': True
+        }
+
+        for waiter in LiveReloadHandler.waiters:
+            try:
+                waiter.write_message(msg)
+            except:
+                logging.error('Error sending message', exc_info=True)
+                LiveReloadHandler.waiters.remove(waiter)
+
+        self.write("Success!")
+
 
 def create_app(port=35729, root='.'):
     handlers = [
         (r'/livereload', LiveReloadHandler),
         (r'/livereload.js', LiveReloadJSHandler, dict(port=port)),
+        (r'/reload', ForceReloadHandler),
         (r'(.*)', IndexHandler, dict(root=root)),
     ]
     return Application(handlers=handlers)


### PR DESCRIPTION
I couldn't find a way to do this, so I just did it myself.  I am using this as part of the watch/build process and finding that sometimes livereload will reload the page while I'm waiting for something else to finish processing.  When that process is finished I wanted to force a page reload.  I couldn't find a way to do this by looking at the source, so I ended up adding an endpoint @ /reload that will force a reload on all of the waiters.

Even if there is a way to do this within the context of the running python livereload script, this would give the ability to do it outside of that context (scripts/applications running beside livereload).
