### PR TITLE
Allow manually defining tasks in library use.

### DIFF
--- a/livereload/server.py
+++ b/livereload/server.py
@@ -102,6 +102,10 @@ class LiveReloadHandler(WebSocketHandler):
                 if os.path.exists('Guardfile'):
                     logging.info('Reading Guardfile')
                     execfile('Guardfile', {})
+                elif Task.tasks:
+                    # Tasks have been added through library-use.
+                    logging.debug('Not loading any tasks, library-use.')
+                    pass
                 else:
                     logging.info('No Guardfile')
                     Task.add(os.getcwd())


### PR DESCRIPTION
I want to be able to use livereload as part of my projects "runserver". For a perfect integration, there are a number of changes that could be done, but this is the most important one - allow me to manually add my tasks without interference.
