### PR TITLE
Added path param for force reload

### DIFF
--- a/livereload/handlers.py
+++ b/livereload/handlers.py
@@ -128,8 +128,9 @@ class ForceReloadHandler(RequestHandler):
     def get(self):
         msg = {
             'command': 'reload',
-            'path': '*',
-            'liveCSS': True
+            'path': self.get_argument('path', default=None) or '*',
+            'liveCSS': True,
+            'liveImg': True
         }
         for waiter in LiveReloadHandler.waiters:
             try:


### PR DESCRIPTION
@lepture

I thought of something else for the reload handler.  This allows for passing the path so that LiveCSS and LiveImg can function correctly.
