### PR TITLE
Added `bin/livereload`

### DIFF
--- a/bin/livereload
+++ b/bin/livereload
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+
+import argparse
+from livereload.server import Server
+
+def main():
+    """Define command to parse CLI arguments and start `livereload` server"""
+    # Parse our arguments
+    parser = argparse.ArgumentParser(description='Start a `livereload` server')
+    parser.add_argument('-p', '--port',
+        help='Port to run `livereload` server on', type=int, default=35729)
+    parser.add_argument('directory',
+        help='Directory to watch for changes', type=str, default='.', nargs='?')
+    args = parser.parse_args()
+
+    # Create a new application
+    server = Server()
+    server.serve(port=args.port, root=args.directory)
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,9 @@ setup(
     packages=['livereload'],
     description='Python LiveReload is an awesome tool for web developers',
     long_description=fread('README.rst'),
+    scripts=[
+        'bin/livereload',
+    ],
     install_requires=[
         'tornado',
     ],


### PR DESCRIPTION
As discussed in #54, I have added an executable script which was previously removed in `2.0.0`. In this PR:
- Added `bin/livereload` to `setup.py's scripts`
- Added `argparse` based script that starts a `livereload` server
  - Defaults port to standard `35729` and watching local directory

Fixes #54

/cc @lepture
