### PR TITLE
Documented `livereload` CLI utility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,26 @@ If you don't have pip installed, try easy_install::
 
     $ easy_install livereload
 
+Command Line Interface
+----------------------
+
+Python LiveReload provides a command line utility, ``livereload``, for starting a server in a directory.
+
+By default, it will listen to port 35729, the common port for `LiveReload browser extensions`_. ::
+
+    $ livereload --help
+    usage: livereload [-h] [-p PORT] [directory]
+
+    Start a `livereload` server
+
+    positional arguments:
+      directory             Directory to watch for changes
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      -p PORT, --port PORT  Port to run `livereload` server on
+
+.. _`livereload browser extensions`: http://feedback.livereload.com/knowledgebase/articles/86242-how-do-i-install-and-use-the-browser-extensions-
 
 Developer Guide
 ---------------


### PR DESCRIPTION
As commented in #56, while we have added `bin/livereload`, we did not document it. In this PR:
- Add documentation for Command Line Interface (`bin/livereload`)
