### PR TITLE
Fix Windows compatibility

### DIFF
--- a/livereload/handlers.py
+++ b/livereload/handlers.py
@@ -149,9 +149,9 @@ class StaticHandler(RequestHandler):
 
     def filepath(self, url):
         url = url.lstrip('/')
-        url = os.path.normpath(os.path.join(self._root, url))
+        url = os.path.join(self._root, url)
 
-        if url.endswith(os.sep):
+        if url.endswith(os.sep) or url.endswith('/'):
             url += 'index.html'
         elif not os.path.exists(url) and not url.endswith('.html'):
             url += '.html'


### PR DESCRIPTION
This patch fixes 2 problems that occur when using livereload on Windows:

The first problem is that index.html was not fetched when the url ends with '/' (this is because Windows paths are separated with '\', and os.path.join uses it).

The second problem is when handling binary files, Windows needs the file to be opened in binary mode, or else it converts the 0x0A characters into the 0x0D, 0x0A sequence.

This patch fixes both problems, and it has been succesfully tested both on Windows and on Linux.
