### PR TITLE
Fix error to send image file on Python 3.x

### DIFF
--- a/livereload/handlers.py
+++ b/livereload/handlers.py
@@ -180,8 +180,12 @@ class StaticHandler(RequestHandler):
         self.mime_type = mime_type
         self.set_header('Content-Type', mime_type)
 
-        with open(filepath, 'r') as f:
-            data = f.read()
+        if mime_type.startswith('text'):
+            with open(filepath, 'r') as f:
+                data = f.read()
+        else:
+            with open(filepath, 'rb') as f:
+                data = f.read()
 
         hasher = hashlib.sha1()
         hasher.update(to_bytes(data))


### PR DESCRIPTION
On Python 3.x, we have to treat binary and text separately.

If we open image file with only 'r' mode option, we encounter following error.

```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x89 in position 0: invalid start byte
```

And if we open text file with 'rb' mode option, we encounter following error.

```
TypeError: expected bytes, bytearray or buffer compatible object
```

This patch checks guessed `mime_type` along with [Media Types](http://www.iana.org/assignments/media-types/media-types.xhtml) rules. I tested with Python 3.4 and Python 2.7 on MacOSX.
