### PR TITLE
tell livereload server to watch the directory specified

### DIFF
--- a/bin/livereload
+++ b/bin/livereload
@@ -25,6 +25,7 @@ def main():
 
     # Create a new application
     server = Server()
+    server.watcher.watch(args.directory)
     server.serve(port=args.port, root=args.directory)
 
 if __name__ == '__main__':


### PR DESCRIPTION
When running livereload from the command line, it watches the the current working directory even if you tell it to watch another directory. This commit adds a line to tell the server to correctly watch the directory the user passed in.
