### PR TITLE
Make URL clickable that is printed on serve

### DIFF
--- a/livereload/server.py
+++ b/livereload/server.py
@@ -209,7 +209,7 @@ class Server(object):
         logging.getLogger().setLevel(logging.INFO)
 
         host = host or '127.0.0.1'
-        print('Serving on %s:%s' % (host, self.port))
+        print('Serving on http://%s:%s' % (host, self.port))
 
         # Async open web browser after 5 sec timeout
         if open_url:


### PR DESCRIPTION
When there's the "http://" prefix, my terminal emulator (yakuake) makes the link clickable. Convenient. :)
