### PR TITLE
When the listen host is left implicit, the console message is wrong.

### DIFF
--- a/livereload/server.py
+++ b/livereload/server.py
@@ -227,7 +227,7 @@ class Server(object):
         self.application(port, host, liveport=liveport, debug=debug)
         logging.getLogger().setLevel(logging.INFO)
 
-        host = host or '127.0.0.1'
+        host = host or '0.0.0.0'
         print('Serving on http://%s:%s' % (host, port))
 
         # Async open web browser after 5 sec timeout


### PR DESCRIPTION
Console says we're listening to 127.0.0.1, while we're really listening on 0.0.0.0 . 

Your project is really useful by the way, I use it almost every day. Thanks!

Cheers, Bram
