### PR TITLE
Add parameter in watch function of INotifyWatcher

### DIFF
--- a/livereload/watcher.py
+++ b/livereload/watcher.py
@@ -130,7 +130,7 @@ class INotifyWatcher(Watcher):
         import pyinotify
         flag = pyinotify.IN_CREATE | pyinotify.IN_DELETE | pyinotify.IN_MODIFY
         self.wm.add_watch(path, flag, rec=True, do_glob=True, auto_add=True)
-        Watcher.watch(self, path, func)
+        Watcher.watch(self, path, func, delay)
 
     def inotify_event(self, event):
         self.callback()


### PR DESCRIPTION
if we use INotifyWatcher, server.watch won't be work because of TypeError ( watch() takes at most 3 arguments (4 given) ). 
