### PR TITLE
Fix UnicodeDecodeError occurs some locales on Python 3

### DIFF
--- a/livereload/handlers.py
+++ b/livereload/handlers.py
@@ -196,10 +196,8 @@ class StaticHandler(RequestHandler):
             data = f.read()
 
         if mime_type.startswith('text'):
-            detected_result = chardet.detect(data)
-            if detected_result:
-                encoding = detected_result['encoding']
-            else:
+            encoding = chardet.detect(data)['encoding']
+            if not encoding:
                 encoding = locale.getpreferredencoding(False)
             data = data.decode(encoding)
 

--- a/livereload/handlers.py
+++ b/livereload/handlers.py
@@ -187,7 +187,7 @@ class StaticHandler(RequestHandler):
 
         mime_type, _ = mimetypes.guess_type(filepath)
         if not mime_type:
-            mime_type = 'text/html'
+            mime_type = 'application/octet-stream'
 
         self.mime_type = mime_type
         self.set_header('Content-Type', mime_type)

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         'bin/livereload',
     ],
     install_requires=[
+        'chardet',
         'tornado',
     ],
     license='BSD',


### PR DESCRIPTION
On Python 3, if encoding is not set when text file opens,
locale.getpreferredencoding(False) is used as encoding.
And when encoding of text data is different from
locale.getpreferredencoding(False), UnicodeDecodeError may
occur while reading.

For example, when UTF-8 data is read if locale.getpreferredencoding(False)
returnes "cp932", UnicodeDecodeError occurs.

> Traceback (most recent call last):
> File "C:\Python34\lib\site-packages\tornado\web.py", line 1332, in _execute result = method(*self.path_args, **self.path_kwargs)
> File "C:\Python34\lib\site-packages\livereload\handlers.py", line 195, in get data = f.read()
> UnicodeDecodeError: 'cp932' codec can't decode byte 0x84 in position 1681: illegal multibyte sequence

Therefore, this commit detects encoding of text data by
chardet.

Detected encoding is used if chardet can detect it. But
if chardet cannot detect encoding, default encoding of
open() on Python 3 is used.