### PR TITLE
Add ``shell`` parameter for shell.

### DIFF
--- a/livereload/server.py
+++ b/livereload/server.py
@@ -27,8 +27,8 @@ from tornado.log import enable_pretty_logging
 enable_pretty_logging()
 
 
-def shell(command, output=None, mode='w', cwd=None, shell=False):
-    """Command shell command.
+def shell(cmd, output=None, mode='w', cwd=None, shell=False):
+    """Execute a shell command.
 
     You can add a shell command::
 
@@ -36,7 +36,7 @@ def shell(command, output=None, mode='w', cwd=None, shell=False):
             'style.less', shell('lessc style.less', output='style.css')
         )
 
-    :param command: a shell command, string or list
+    :param cmd: a shell command, string or list
     :param output: output stdout to the given file
     :param mode: only works with output, mode ``w`` means write,
                  mode ``a`` means append
@@ -51,10 +51,8 @@ def shell(command, output=None, mode='w', cwd=None, shell=False):
         if folder and not os.path.isdir(folder):
             os.makedirs(folder)
 
-    if isinstance(command, (list, tuple)):
-        cmd = command
-    else:
-        cmd = command.split()
+    if not isinstance(cmd, (list, tuple)) and not shell:
+        cmd = cmd.split()
 
     def run_shell():
         try:

--- a/livereload/server.py
+++ b/livereload/server.py
@@ -27,7 +27,7 @@ from tornado.log import enable_pretty_logging
 enable_pretty_logging()
 
 
-def shell(command, output=None, mode='w', cwd=None):
+def shell(command, output=None, mode='w', cwd=None, shell=False):
     """Command shell command.
 
     You can add a shell command::
@@ -40,6 +40,9 @@ def shell(command, output=None, mode='w', cwd=None):
     :param output: output stdout to the given file
     :param mode: only works with output, mode ``w`` means write,
                  mode ``a`` means append
+    :param cwd: set working directory before command is executed.
+    :param shell: if true, on Unix the executable argument specifies a
+                  replacement shell for the default ``/bin/sh``.
     """
     if not output:
         output = os.devnull
@@ -55,7 +58,8 @@ def shell(command, output=None, mode='w', cwd=None):
 
     def run_shell():
         try:
-            p = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE, cwd=cwd)
+            p = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE, cwd=cwd,
+                      shell=shell)
         except OSError as e:
             logging.error(e)
             if e.errno == os.errno.ENOENT:  # file (command) not found


### PR DESCRIPTION
@lepture 

We can use glob in command by setting shell to True:

```python
shell('ls *.html', output='result.txt', cwd='./pages', shell=True)
```

So we don't need to use `glob` to grab the list of `./pages/*.html`.