### PR TITLE
'make docs': initialize git submodules automatically

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -39,7 +39,7 @@ help:
 clean:
 	-rm -rf $(BUILDDIR)/*
 
-html:
+html: _themes/.git
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
@@ -149,3 +149,7 @@ doctest:
 	$(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(BUILDDIR)/doctest
 	@echo "Testing of doctests in the sources finished, look at the " \
 	      "results in $(BUILDDIR)/doctest/output.txt."
+
+
+_themes/.git:
+	git submodule update --init


### PR DESCRIPTION
Otherwise the build fails with a cryptic theme error:

    no theme named 'flask_small' found (missing theme.conf?)