### PR TITLE
Document restart_delay & add start_delay as parameter instead of fixed value

### DIFF
--- a/livereload/server.py
+++ b/livereload/server.py
@@ -262,6 +262,7 @@ class Server(object):
                       via Tornado (and causes polling). Defaults to True when
                       ``self.app`` is set, otherwise False.
         :param open_url: open system browser
+        :param restart_delay: delay before reload, default is 2 seconds
         """
         host = host or '127.0.0.1'
         if root is not None:

--- a/livereload/server.py
+++ b/livereload/server.py
@@ -251,7 +251,7 @@ class Server(object):
         ]
 
     def serve(self, port=5500, liveport=None, host=None, root=None, debug=None,
-              open_url=False, restart_delay=2):
+              open_url=False, restart_delay=2, start_delay=5):
         """Start serve the server with the given port.
 
         :param port: serve on this port, default is 5500
@@ -263,6 +263,7 @@ class Server(object):
                       ``self.app`` is set, otherwise False.
         :param open_url: open system browser
         :param restart_delay: delay before reload, default is 2 seconds
+        :param start_delay: delay before starting server, default is 5 seconds
         """
         host = host or '127.0.0.1'
         if root is not None:
@@ -273,10 +274,10 @@ class Server(object):
 
         self.application(port, host, liveport=liveport, debug=debug)
 
-        # Async open web browser after 5 sec timeout
+        # Async open web browser after start_delay sec timeout
         if open_url:
             def opener():
-                time.sleep(5)
+                time.sleep(start_delay)
                 webbrowser.open('http://%s:%s' % (host, port))
             threading.Thread(target=opener).start()
 

--- a/livereload/server.py
+++ b/livereload/server.py
@@ -251,7 +251,7 @@ class Server(object):
         ]
 
     def serve(self, port=5500, liveport=None, host=None, root=None, debug=None,
-              open_url=False, restart_delay=2, start_delay=5):
+              open_url_delay=None, restart_delay=2):
         """Start serve the server with the given port.
 
         :param port: serve on this port, default is 5500
@@ -275,9 +275,9 @@ class Server(object):
         self.application(port, host, liveport=liveport, debug=debug)
 
         # Async open web browser after start_delay sec timeout
-        if open_url:
+        if open_url_delay is not None:
             def opener():
-                time.sleep(start_delay)
+                time.sleep(open_url_delay)
                 webbrowser.open('http://%s:%s' % (host, port))
             threading.Thread(target=opener).start()
 


### PR DESCRIPTION
As in title - fixes #86 and adds doc to one parameter. I have put start_delay after restart_delay for compatibility, even though it would probably make sense to have those parameters the other way around.