### PR TITLE
Watcher.examine: log running task

### DIFF
--- a/livereload/server.py
+++ b/livereload/server.py
@@ -196,7 +196,11 @@ class Server(object):
                       css, but reload on changed css files then only.
         """
         if isinstance(func, string_types):
+            cmd = func
             func = shell(func)
+            func.repr_str = "shell: {}".format(cmd)
+        elif func:
+            func.repr_str = str(func)
 
         self.watcher.watch(filepath, func, delay)
 

--- a/livereload/watcher.py
+++ b/livereload/watcher.py
@@ -9,13 +9,17 @@
     :license: BSD, see LICENSE for more details.
 """
 
-import os
 import glob
+import logging
+import os
 import time
+
 try:
     import pyinotify
 except ImportError:
     pyinotify = None
+
+logger = logging.getLogger('livereload')
 
 
 class Watcher(object):
@@ -70,10 +74,13 @@ class Watcher(object):
             item = self._tasks[path]
             if self.is_changed(path, item['ignore']):
                 func = item['func']
-                func and func()
                 delay = item['delay']
                 if delay and isinstance(delay, int):
                     delays.add(delay)
+                if func:
+                    logger.info("Running task: {} (delay: {})".format(
+                        func.repr_str, delay))
+                    func()
 
         if delays:
             delay = max(delays)


### PR DESCRIPTION
This logs the tasks being run, and adds `func.repr_str` to the task
function, which contains the shell command for string "functions".
