### PR TITLE
Expose delay parameter in command line tool

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Python LiveReload provides a command line utility, ``livereload``, for starting 
 By default, it will listen to port 35729, the common port for `LiveReload browser extensions`_. ::
 
     $ livereload --help
-    usage: livereload [-h] [-p PORT] [directory]
+    usage: livereload [-h] [-p PORT] [-w WAIT] [directory]
 
     Start a `livereload` server
 
@@ -42,6 +42,7 @@ By default, it will listen to port 35729, the common port for `LiveReload browse
     optional arguments:
       -h, --help            show this help message and exit
       -p PORT, --port PORT  Port to run `livereload` server on
+      -w WAIT, --wait WAIT  Time delay before reloading
 
 .. _`livereload browser extensions`: http://feedback.livereload.com/knowledgebase/articles/86242-how-do-i-install-and-use-the-browser-extensions-
 

--- a/livereload/cli.py
+++ b/livereload/cli.py
@@ -22,6 +22,12 @@ parser.add_argument(
     default='.',
     nargs='?'
 )
+parser.add_argument(
+    '-w', '--wait',
+    help='Time delay in seconds before reloading',
+    type=int,
+    default=0
+)
 
 
 def main(argv=None):
@@ -29,5 +35,5 @@ def main(argv=None):
 
     # Create a new application
     server = Server()
-    server.watcher.watch(args.directory)
+    server.watcher.watch(args.directory, delay=args.wait)
     server.serve(host=args.host, port=args.port, root=args.directory)


### PR DESCRIPTION
Add --wait parameter, useful when working with templates that need to be regenerated before reloading