### PR TITLE
Add theme option for GitHub link

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -100,6 +100,7 @@ html_theme = 'flask_small'
 # documentation.
 html_theme_options = {
     'index_logo': None,
+    'github_fork': 'lepture/python-livereload',
 }
 
 # Add any paths that contain custom themes here, relative to this directory.


### PR DESCRIPTION
Closes #117

Fixes the GitHub ribbon link here: https://livereload.readthedocs.org/en/latest/