### PR TITLE
Modified Server.watch() to be backwards compatible with pre-v2.4.1 API

### DIFF
--- a/livereload/server.py
+++ b/livereload/server.py
@@ -200,7 +200,10 @@ class Server(object):
         if isinstance(func, string_types):
             func = shell(func)
 
-        self.watcher.watch(filepath, func, delay, ignore=ignore)
+        kargs = {}
+        if ignore is not None: kargs['ignore'] = ignore 
+        
+        self.watcher.watch(filepath, func, delay, **kargs)
 
     def application(self, port, host, liveport=None, debug=None):
         LiveReloadHandler.watcher = self.watcher


### PR DESCRIPTION
Previous to version v2.4.1, when a new item was added to the watch list by calling Server.watch(), there were 3 arguments passed to the watcher's watch() method: filepath, func, and delay. With v2.4.1, that changed to include a fourth parameter: ignore. This new feature is useful but unfortunately breaks some dependent packages that depend on the previous API (e.g. sphinx-autobuild). I'm sure many of those packages will eventually update their implementations to support the new API but in the meantime and for those packages that never do, we should try to maintain backwards compatibility. 

Since `ignore` is an optional parameter, my change simply only passes it to the watcher if it was set by the caller. If they don't make the call to Server with the new API then we don't (potentially) make a call back to the watcher with that API. 