### PR TITLE
use glob2 instead of stdlib glob to support recursive directories

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,11 +96,11 @@ The ``Server`` class accepts parameters:
 server.watch
 ~~~~~~~~~~~~
 
-``server.watch`` can watch a filepath, a directory and a glob pattern::
+``server.watch`` can watch a filepath, a directory and a glob2 pattern::
 
     server.watch('path/to/file.txt')
     server.watch('directory/path/')
-    server.watch('glob/*.pattern')
+    server.watch('glob2/*.pattern')
 
 You can also use other library (for example: formic) for more powerful
 file adding::

--- a/livereload/server.py
+++ b/livereload/server.py
@@ -187,7 +187,7 @@ class Server(object):
             server.serve()
 
         :param filepath: files to be watched, it can be a filepath,
-                         a directory, or a glob pattern
+                         a directory, or a glob2 pattern
         :param func: the function to be called, it can be a string of
                      shell command, or any callable object without
                      parameters

--- a/livereload/watcher.py
+++ b/livereload/watcher.py
@@ -10,7 +10,7 @@
 """
 
 import os
-import glob
+import glob2
 import time
 try:
     import pyinotify
@@ -39,7 +39,7 @@ class Watcher(object):
     def watch(self, path, func=None, delay=0, ignore=None):
         """Add a task to watcher.
 
-        :param path: a filepath or directory path or glob pattern
+        :param path: a filepath or directory path or glob2 pattern
         :param func: the function to be executed when file changed
         :param delay: Delay sending the reload message. Use 'forever' to
                       not send it. This is useful to compile sass files to
@@ -130,7 +130,7 @@ class Watcher(object):
         return False
 
     def is_glob_changed(self, path, ignore=None):
-        for f in glob.glob(path):
+        for f in glob2.glob(path):
             if self.is_file_changed(f, ignore):
                 return True
         return False

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         ]
     },
     install_requires=[
+        'glob2',
         'tornado',
         'six',
     ],


### PR DESCRIPTION
It would be nice to use glob2 to support recursive file discovery - https://pypi.python.org/pypi/glob2
