### PR TITLE
Support waiting parts of seconds

### DIFF
--- a/livereload/cli.py
+++ b/livereload/cli.py
@@ -25,8 +25,8 @@ parser.add_argument(
 parser.add_argument(
     '-w', '--wait',
     help='Time delay in seconds before reloading',
-    type=int,
-    default=0
+    type=float,
+    default=0.0
 )
 
 

--- a/livereload/watcher.py
+++ b/livereload/watcher.py
@@ -72,7 +72,7 @@ class Watcher(object):
                 func = item['func']
                 func and func()
                 delay = item['delay']
-                if delay and isinstance(delay, int):
+                if delay and isinstance(delay, float):
                     delays.add(delay)
 
         if delays:


### PR DESCRIPTION
`--wait` is great for waiting for build processes to complete that can't be well integrated. Unfortunately, sometimes full seconds are too granular (e.g. sometimes waiting `0.2s` would be ideal). Tornado supports floating point seconds already so this is a simple integration:

http://www.tornadoweb.org/en/stable/ioloop.html#tornado.ioloop.IOLoop.time

In this PR:

- Moved `--wait`/`delay` from `int` to `float