### PR TITLE
Ensure current version of pyinotify is installed before using.

### DIFF
--- a/livereload/watcher.py
+++ b/livereload/watcher.py
@@ -166,6 +166,6 @@ class INotifyWatcher(Watcher):
 
 
 def get_watcher_class():
-    if pyinotify is None:
+    if pyinotify is None or not hasattr(pyinotify, 'TornadoAsyncNotifier'):
         return Watcher
     return INotifyWatcher


### PR DESCRIPTION
As pyinotify is not a dependency that gets installed, some users may already
have an older version installed which does not include Tornado support (added
in pyinotify version 0.9.4). Unfortunately, pyinotify does not make their
version available programicaly, so we check that the neccessary class is
present. Now users with older versions will fall back gracefully just like
those who do not have any version isntalled.

For reference, at mkdocs/mkdocs#1119 we've had a few users run into this. They get an ugly error and at first we thought it was because they were using an older version of Python. Turns out they just needed to upgrade pyinotify. 