### PR TITLE
Allow server sitting behind reverse proxy with SSL.

### DIFF
--- a/livereload/server.py
+++ b/livereload/server.py
@@ -221,7 +221,7 @@ class Server(object):
         # This allows for serving on 0.0.0.0.
         live_script = escape.utf8((
             '<script type="text/javascript">'
-            'document.write("<script src=''http://"'
+            'document.write("<script src=''//"'
             ' + window.location.hostname + ":{port}/livereload.js''>'
             ' </"+"script>");'
             '</script>'

--- a/livereload/vendors/livereload.js
+++ b/livereload/vendors/livereload.js
@@ -12,7 +12,7 @@
       this.WebSocket = WebSocket;
       this.Timer = Timer;
       this.handlers = handlers;
-      this._uri = "ws://" + this.options.host + ":" + this.options.port + "/livereload";
+      this._uri = ((window.location.protocol == "https:") ? "wss://" : "ws://") + this.options.host + ":" + this.options.port + "/livereload";
       this._nextDelay = this.options.mindelay;
       this._connectionDesired = false;
       this.protocol = 0;


### PR DESCRIPTION
  - Use protocol-relative URL to access livereload.js.
  - Talk to WebSocket Secure (wss://) when HTTPS is in use.