### PR TITLE
Add universal wheel support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[bdist_wheel]
+universal = 1
+
+[metadata]
+license_file = LICENSE


### PR DESCRIPTION
The current wheel on PyPI is listed as Python2 only. As this project is pure Python and supports both Python 2 and 3, it should be released as a universal wheel. As of now, Python 3 users do not get the benefits of the wheel package:

* Faster installation
* Avoids arbitrary code execution for installation by avoiding setup.py
* Allows better caching for testing and continuous integration.
* Creates .pyc files as part of installation to ensure they match the python interpreter used.
* More consistent installs across platforms and machines.

For more information on universal wheels, see:

https://pythonwheels.com/