### PR TITLE
Update docs about bottle template caching

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -194,6 +194,10 @@ Wrap the ``Bottle`` app with livereload server:
 
 .. code:: python
 
+    # Without this line templates won't auto reload because of caching.
+    # http://bottlepy.org/docs/dev/tutorial.html#templates
+    bottle.debug(True)
+
     app = Bottle()
     server = Server(app)
     # server.watch


### PR DESCRIPTION
I spent quite some time while I finally found the reason, why Bottle
templates won't auto reload. I thing this should be mentioned in the
docs.