### PR TITLE
test_watcher: fix a failing test

### DIFF
--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -53,6 +53,8 @@ class TestWatcher(unittest.TestCase):
 
         def add_count():
             watcher.count += 1
+            
+        add_count.repr_str = "add_count test task"
 
         watcher.watch(filepath, add_count)
         assert watcher.is_changed(filepath)


### PR DESCRIPTION
Due to a missing repr_str attribute, the function `add_count` in `TestWatcher.test_watch_file` triggered an error in `Watcher.examine()`.

Closes #171