### PR TITLE
You cannot remove an item from a set while iterating through it

### DIFF
--- a/livereload/handlers.py
+++ b/livereload/handlers.py
@@ -103,7 +103,7 @@ class LiveReloadHandler(WebSocketHandler):
         }
 
         cls._last_reload_time = time.time()
-        for waiter in cls.waiters:
+        for waiter in cls.waiters.copy():
             try:
                 waiter.write_message(msg)
             except:


### PR DESCRIPTION
This fixes a bug that results in `RuntimeError: Set changed size during iteration` when a waiter is removed during iteration over the waiters.