### PR TITLE
use default ports when windows.location.protocol is an empty string

### DIFF
--- a/livereload/server.py
+++ b/livereload/server.py
@@ -236,7 +236,7 @@ class Server(object):
         if liveport:
             live_script = escape.utf8(live_script % liveport)
         else:
-            live_script = escape.utf8(live_script % 'window.location.port')
+            live_script = escape.utf8(live_script % '("" == window.location.port) ? ((window.location.protocol == "https:") ? 443: 80) : window.location.port')
 
         web_handlers = self.get_web_handlers(live_script)
 


### PR DESCRIPTION
This is a proposed solution to issue#194 livereload uses port 0 when website is on default ports.

Please consider picking this up or equivalent fix to enable livereload on default ports. This would enable livereload to work using ngrok or other reverse proxy config.