### PR TITLE
Trigger reload on deleted files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,13 +17,11 @@ build
 
 pip-log.txt
 
-.vscode
 .idea
 .coverage
 .tox
 .env/
 venv/
-.envrc
 
 docs/_build
 example/style.css

--- a/.gitignore
+++ b/.gitignore
@@ -17,10 +17,13 @@ build
 
 pip-log.txt
 
+.vscode
 .idea
 .coverage
 .tox
 .env/
+venv/
+.envrc
 
 docs/_build
 example/style.css

--- a/livereload/watcher.py
+++ b/livereload/watcher.py
@@ -122,6 +122,8 @@ class Watcher(object):
         if not changed:
             changed = self.is_file_removed()
 
+        # TODO: This causes constant reloading with multiple _tasks,
+        # because it discards filepaths outside of current path
         self._mtimes = self._new_mtimes
         return changed
 

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -106,3 +106,28 @@ class TestWatcher(unittest.TestCase):
             f.write('')
 
         assert watcher.examine() == (None, None)
+
+    def test_watch_multiple_dirs(self):
+        first_dir = os.path.join(tmpdir, 'first')
+        second_dir = os.path.join(tmpdir, 'second')
+
+        watcher = Watcher()
+
+        os.mkdir(first_dir)
+        watcher.watch(first_dir)
+        assert watcher.examine() == (None, None)
+
+        first_path = os.path.join(first_dir, 'foo')
+        with open(first_path, 'w') as f:
+            f.write('')
+        assert watcher.examine() == (first_path, None)
+
+        os.mkdir(second_dir)
+        watcher.watch(second_dir)
+        # TODO: Failing, because of is_changed implementation
+        assert watcher.examine() == (None, None)
+
+        second_path = os.path.join(second_dir, 'foo')
+        with open(second_path, 'w') as f:
+            f.write('')
+        assert watcher.examine() == (second_path, None)

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -34,11 +34,16 @@ class TestWatcher(unittest.TestCase):
         # sleep 1 second so that mtime will be different
         time.sleep(1)
 
-        with open(os.path.join(tmpdir, 'foo'), 'w') as f:
+        filepath = os.path.join(tmpdir, 'foo')
+
+        with open(filepath, 'w') as f:
             f.write('')
 
         assert watcher.is_changed(tmpdir)
         assert watcher.is_changed(tmpdir) is False
+
+        os.remove(filepath)
+        assert watcher.is_changed(tmpdir)
 
     def test_watch_file(self):
         watcher = Watcher()
@@ -63,9 +68,13 @@ class TestWatcher(unittest.TestCase):
         with open(filepath, 'w') as f:
             f.write('')
 
-        rv = watcher.examine()
-        assert rv[0] == os.path.abspath(filepath)
+        abs_filepath = os.path.abspath(filepath)
+        assert watcher.examine() == (abs_filepath, None)
         assert watcher.count == 1
+
+        os.remove(filepath)
+        assert watcher.examine() == (abs_filepath, None)
+        assert watcher.count == 2
 
     def test_watch_glob(self):
         watcher = Watcher()
@@ -82,8 +91,11 @@ class TestWatcher(unittest.TestCase):
         with open(filepath, 'w') as f:
             f.write('')
 
-        rv = watcher.examine()
-        assert rv[0] == os.path.abspath(filepath)
+        abs_filepath = os.path.abspath(filepath)
+        assert watcher.examine() == (abs_filepath, None)
+
+        os.remove(filepath)
+        assert watcher.examine() == (abs_filepath, None)
 
     def test_watch_ignore(self):
         watcher = Watcher()

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -32,6 +32,7 @@ class TestWatcher(unittest.TestCase):
         assert watcher.is_changed(tmpdir) is False
 
         # sleep 1 second so that mtime will be different
+        # TODO: This doesn't seem necessary; test passes without it
         time.sleep(1)
 
         filepath = os.path.join(tmpdir, 'foo')
@@ -44,12 +45,14 @@ class TestWatcher(unittest.TestCase):
 
         os.remove(filepath)
         assert watcher.is_changed(tmpdir)
+        assert watcher.is_changed(tmpdir) is False
 
     def test_watch_file(self):
         watcher = Watcher()
         watcher.count = 0
 
         # sleep 1 second so that mtime will be different
+        # TODO: This doesn't seem necessary; test passes without it
         time.sleep(1)
 
         filepath = os.path.join(tmpdir, 'foo')
@@ -61,8 +64,10 @@ class TestWatcher(unittest.TestCase):
 
         watcher.watch(filepath, add_count)
         assert watcher.is_changed(filepath)
+        assert watcher.is_changed(filepath) is False
 
         # sleep 1 second so that mtime will be different
+        # TODO: This doesn't seem necessary; test passes without it
         time.sleep(1)
 
         with open(filepath, 'w') as f:
@@ -70,10 +75,12 @@ class TestWatcher(unittest.TestCase):
 
         abs_filepath = os.path.abspath(filepath)
         assert watcher.examine() == (abs_filepath, None)
+        assert watcher.examine() == (None, None)
         assert watcher.count == 1
 
         os.remove(filepath)
         assert watcher.examine() == (abs_filepath, None)
+        assert watcher.examine() == (None, None)
         assert watcher.count == 2
 
     def test_watch_glob(self):
@@ -93,9 +100,11 @@ class TestWatcher(unittest.TestCase):
 
         abs_filepath = os.path.abspath(filepath)
         assert watcher.examine() == (abs_filepath, None)
+        assert watcher.examine() == (None, None)
 
         os.remove(filepath)
         assert watcher.examine() == (abs_filepath, None)
+        assert watcher.examine() == (None, None)
 
     def test_watch_ignore(self):
         watcher = Watcher()
@@ -121,13 +130,23 @@ class TestWatcher(unittest.TestCase):
         with open(first_path, 'w') as f:
             f.write('')
         assert watcher.examine() == (first_path, None)
+        assert watcher.examine() == (None, None)
 
         os.mkdir(second_dir)
         watcher.watch(second_dir)
-        # TODO: Failing, because of is_changed implementation
         assert watcher.examine() == (None, None)
 
-        second_path = os.path.join(second_dir, 'foo')
+        second_path = os.path.join(second_dir, 'bar')
         with open(second_path, 'w') as f:
             f.write('')
         assert watcher.examine() == (second_path, None)
+        assert watcher.examine() == (None, None)
+
+        with open(first_path, 'a') as f:
+            f.write('foo')
+        assert watcher.examine() == (first_path, None)
+        assert watcher.examine() == (None, None)
+
+        os.remove(second_path)
+        assert watcher.examine() == (second_path, None)
+        assert watcher.examine() == (None, None)


### PR DESCRIPTION
Fixes #197.

- Adds assertions for deleting files to existing tests
- Detects file deletion with a "before" and "after" dictionary of modification times
- Adds docstrings to relevant methods
- Ignores common `venv` directory