### PR TITLE
@ #132 | Script specifies host and port which breaks reverse proxies

### DIFF
--- a/livereload/server.py
+++ b/livereload/server.py
@@ -236,7 +236,7 @@ class Server(object):
         if liveport:
             live_script = escape.utf8(live_script % liveport)
         else:
-            live_script = escape.utf8(live_script % 'window.location.port')
+            live_script = escape.utf8(live_script % "(window.location.port || (window.location.protocol == 'https:' ? 443: 80))")
 
         web_handlers = self.get_web_handlers(live_script)
 


### PR DESCRIPTION
I added the fix when `liveport` is None running on a reverse proxy