### PR TITLE
Support ** recursive globs by default - close #156

### DIFF
--- a/livereload/watcher.py
+++ b/livereload/watcher.py
@@ -13,6 +13,7 @@ import glob
 import logging
 import os
 import time
+import sys
 
 try:
     import pyinotify
@@ -192,7 +193,11 @@ class Watcher(object):
 
     def is_glob_changed(self, path, ignore=None):
         """Check if glob path has any changed filepaths."""
-        for f in glob.glob(path):
+        if sys.version_info[0] >=3 and sys.version_info[1] >=5:
+            files = glob.glob(path, recursive=True)
+        else:
+            files = glob.glob(path)
+        for f in files:
             if self.is_file_changed(f, ignore):
                 return True
         return False


### PR DESCRIPTION
Sadly, currently `**` glob patterns are just ignored.
I discovered this due to its usage une the recently introduced [pelican invoke task dedicated to livereload](https://github.com/getpelican/pelican/blob/master/pelican/tools/templates/tasks.py.jinja2#L103)

This has already been suggested as a custom watcher in #156.

However, as [Python 2 end of life is scheduled in less than 6 months](https://pythonclock.org),
I think we could rely on `glob.glob` `recursive` optional argument to be supported fairly often.
Still, this PR is fully backward-compatible as it checks for a Python minimum version of 3.5