### PR TITLE
Pass the list of changed files to the _func_ callback if it supports arguments

### DIFF
--- a/livereload/watcher.py
+++ b/livereload/watcher.py
@@ -13,6 +13,7 @@ import glob
 import logging
 import os
 import time
+import sys
 
 try:
     import pyinotify
@@ -192,7 +193,11 @@ class Watcher(object):
 
     def is_glob_changed(self, path, ignore=None):
         """Check if glob path has any changed filepaths."""
-        for f in glob.glob(path):
+        if sys.version_info[0] >=3 and sys.version_info[1] >=5:
+            files = glob.glob(path, recursive=True)
+        else:
+            files = glob.glob(path)
+        for f in files:
             if self.is_file_changed(f, ignore):
                 return True
         return False


### PR DESCRIPTION
Allows to write callback functions that can limit their processing to the scope of the modified files.

It is fully backward-compatible.

Usage example with globs:
```python
    server = Server()
    server.watch('**/.md', lambda paths: regenerate(paths))
```

This PR currently relies on https://github.com/lepture/python-livereload/pull/203 but could easily be dissociated