### PR TITLE
Allow zero delay when opening browser

### DIFF
--- a/livereload/server.py
+++ b/livereload/server.py
@@ -299,9 +299,9 @@ class Server(object):
             port, host, liveport=liveport, debug=debug, live_css=live_css)
 
         # Async open web browser after 5 sec timeout
-        if open_url or open_url_delay:
-            if open_url:
-                logger.warn('Use `open_url_delay` instead of `open_url`')
+        if open_url:
+            logger.error('Use `open_url_delay` instead of `open_url`')
+        if open_url_delay:
             sleep = open_url_delay or 5
 
             def opener():

--- a/livereload/server.py
+++ b/livereload/server.py
@@ -301,11 +301,10 @@ class Server(object):
         # Async open web browser after 5 sec timeout
         if open_url:
             logger.error('Use `open_url_delay` instead of `open_url`')
-        if open_url_delay:
-            sleep = open_url_delay or 5
+        if open_url_delay is not None:
 
             def opener():
-                time.sleep(sleep)
+                time.sleep(open_url_delay)
                 webbrowser.open('http://%s:%s' % (host, port))
             threading.Thread(target=opener).start()
 


### PR DESCRIPTION
- Log an error instead of a warning, so that the message really stands out.
- Move logging out of the first `if` clause to reduce cyclomatic complexity
- Check if `open_url_delay` is not `None`, to allow for `0` or `0.0` delay values

I can also remove the `open_url` parameter completely, if you allow me to.