### PR TITLE
Windows 3.8 asyncio fix

### DIFF
--- a/livereload/server.py
+++ b/livereload/server.py
@@ -30,10 +30,15 @@ from .watcher import get_watcher_class
 from six import string_types, PY3
 
 import sys
+import asyncio
+
 if sys.version_info >= (3, 7) or sys.version_info.major == 2:
     import errno
 else:
     from os import errno
+
+if sys.version_info >= (3, 8) and sys.platform == 'win32':
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
 logger = logging.getLogger('livereload')
 


### PR DESCRIPTION
Upstream tornado devs are not going to configure the async event
loop due to it causing performance issues on other systems.
Instead they suggest using this workaround.

https://github.com/tornadoweb/tornado/issues/2608