### PR TITLE
install older version of tornado for 2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ setup(
         ]
     },
     install_requires=[
-        'tornado',
+        'tornado;python_version>"2.7"',
+        'tornado==5.1.1;python_version=="2.7"',
         'six',
     ],
     license='BSD',


### PR DESCRIPTION
Adjusts the `install_requires` to install the latest tornado for Python 3.x and limits the version to 5.1.1 if the Python version is 2.7