### PR TITLE
Python 2.7 support

### DIFF
--- a/livereload/server.py
+++ b/livereload/server.py
@@ -30,7 +30,6 @@ from .watcher import get_watcher_class
 from six import string_types, PY3
 
 import sys
-import asyncio
 
 if sys.version_info >= (3, 7) or sys.version_info.major == 2:
     import errno
@@ -38,6 +37,7 @@ else:
     from os import errno
 
 if sys.version_info >= (3, 8) and sys.platform == 'win32':
+    import asyncio
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
 logger = logging.getLogger('livereload')

--- a/livereload/watcher.py
+++ b/livereload/watcher.py
@@ -14,7 +14,11 @@ import logging
 import os
 import time
 import sys
-from inspect import signature
+
+if sys.version_info.major < 3:
+    import inspect
+else:
+    from inspect import signature
 
 try:
     import pyinotify
@@ -105,7 +109,11 @@ class Watcher(object):
                         name = getattr(func, '__name__', 'anonymous')
                     logger.info(
                         "Running task: {} (delay: {})".format(name, delay))
-                    if len(signature(func).parameters) > 0 and isinstance(changed, list):
+                    if sys.version_info.major < 3:
+                        sig_len = len(inspect.getargspec(func)[0])
+                    else:
+                        sig_len = len(signature(func).parameters)
+                    if sig_len > 0 and isinstance(changed, list):
                         func(changed)
                     else:
                         func()

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     },
     install_requires=[
         'tornado;python_version>"2.7"',
-        'tornado==5.1.1;python_version=="2.7"',
+        'tornado<6;python_version=="2.7"',
         'six',
     ],
     license='BSD',


### PR DESCRIPTION
Missed a few things in a couple PRs before.

The watcher no longer worked with Python 2.7 and versions before 3.7 don't have asyncio.