### PR TITLE
Change git submodule URL to use HTTPS scheme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "docs/_themes"]
 	path = docs/_themes
-	url = git://github.com/lepture/flask-sphinx-themes.git
+	url = https://github.com/lepture/flask-sphinx-themes.git


### PR DESCRIPTION
Using the oldstyle git protocol is less efficient and not always available
on a corporate network.