### PR TITLE
Allow control of default filename option

### DIFF
--- a/livereload/server.py
+++ b/livereload/server.py
@@ -306,13 +306,13 @@ class Server(object):
         return [
             (r'/(.*)', self.SFH, {
                 'path': self.root or '.',
-                'default_filename': 'index.html',
+                'default_filename': self.default_filename,
             }),
         ]
 
     def serve(self, port=5500, liveport=None, host=None, root=None, debug=None,
               open_url=False, restart_delay=2, open_url_delay=None,
-              live_css=True):
+              live_css=True, default_filename='index.html'):
         """Start serve the server with the given port.
 
         :param port: serve on this port, default is 5500
@@ -325,6 +325,7 @@ class Server(object):
         :param open_url_delay: open webbrowser after the delay seconds
         :param live_css: whether to use live css or force reload on css.
                          Defaults to True
+        :param default_filename: launch this file from the selected root on startup
         """
         host = host or '127.0.0.1'
         if root is not None:
@@ -332,6 +333,8 @@ class Server(object):
 
         self._setup_logging()
         logger.info('Serving on http://%s:%s' % (host, port))
+
+        self.default_filename = default_filename
 
         self.application(
             port, host, liveport=liveport, debug=debug, live_css=live_css)


### PR DESCRIPTION
The `default_filename` already exists in the server code, it is just hardcoded to `index.html`

This PR allows user control over the default file which is loaded by the server from startup.

I have added this for my specific use case as I would like to transform some input when it changes, and send the output to a specific file. So far, so good - thank you for making this incredibly easy! I would then like the specified file to be opened by default in the browser. Without this option, I could achieve this by setting the file directly as `root`, but this prevented the server from supplying accompanying css and js files. Another workaround is supplying an `index.html` which automatically redirects to the desired location, but generating this on the fly is a bit awkward.

Hopefully this does not affect any of the other running code; as far as I can tell this was the only place where `index.html` was used.

Please let me know if this is helpful, or if there are any other changes you would like me to make.

Thank you once again for making what is already a great and very convenient package 🎉 