### PR TITLE
Honour a watch delay of `forever` (fix: #125)

### DIFF
--- a/livereload/watcher.py
+++ b/livereload/watcher.py
@@ -101,7 +101,7 @@ class Watcher(object):
             if changed:
                 func = item['func']
                 delay = item['delay']
-                if delay and isinstance(delay, float):
+                if delay and isinstance(delay, float) or delay == 'forever':
                     delays.add(delay)
                 if func:
                     name = getattr(func, 'name', None)


### PR DESCRIPTION
Ensure that a delay value of `forever` gets added to the list of returned delays so that we can prevent certain watch events for
triggering a reload.

This is essentially just implementing the work-around proposed by @dwt

ref: https://github.com/lepture/python-livereload/issues/125#issuecomment-246623070