### PR TITLE
CLI flag for using polling based watcher

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -189,6 +189,21 @@ Wrap the ``Bottle`` app with livereload server:
     # server.watch
     server.serve()
 
+
+pyinotify
+---------
+
+If `pyinotify <https://pypi.org/project/pyinotify/>`_ is installed, it will be used for watching file changes instead of the built in polling based watcher. If you prefer to use the built in watcher, specify the ``--poll`` flag on the command line, or initialize the ``Server`` class in a script like in the following
+
+.. code:: python
+	  
+   from livereload import Server
+   from livereload.watcher import Watcher
+   
+   server = Server(watcher=Watcher())
+
+The `pyinotify <https://pypi.org/project/pyinotify/>`_ watcher is more efficient than the built in polling based watcher since it does not have to continously poll, but it might fail if the inode of the watched file changes, as might happen when doing a move or a copy or using certain editors such as vi or emacs with backup settings enabled.
+ 
 Security Report
 ---------------
 

--- a/livereload/cli.py
+++ b/livereload/cli.py
@@ -3,6 +3,7 @@ import argparse
 import tornado.log
 
 from livereload.server import Server
+from livereload.watcher import Watcher
 
 
 parser = argparse.ArgumentParser(description='Start a `livereload` server')
@@ -46,6 +47,11 @@ parser.add_argument(
     help='Enable Tornado pretty logging',
     action='store_true'
 )
+parser.add_argument(
+    '-po', '--poll',
+    help='Use built in polling based watcher instead of pyinotify',
+    action='store_true'
+)
 
 
 def main(argv=None):
@@ -55,7 +61,10 @@ def main(argv=None):
         tornado.log.enable_pretty_logging()
 
     # Create a new application
-    server = Server()
+    if args.poll:
+        server = Server(watcher=Watcher())
+    else:
+        server = Server()
     server.watcher.watch(args.target or args.directory, delay=args.wait)
     server.serve(host=args.host, port=args.port, root=args.directory,
                  open_url_delay=args.open_url_delay)


### PR DESCRIPTION
This PR adds a CLI flag `--poll`, which will make `livereload` use the built in polling based watcher, rather than the `pyinotify` based watcher.
The PR also adds a description of `pyiontify` in the README, as discussed in #143. 