### PR TITLE
Making reload_time in LiveReloadHandler.poll_tasks configurable

### DIFF
--- a/livereload/handlers.py
+++ b/livereload/handlers.py
@@ -24,6 +24,7 @@ logger = logging.getLogger('livereload')
 
 
 class LiveReloadHandler(WebSocketHandler):
+    DEFAULT_RELOAD_TIME = 3
     waiters = set()
     watcher = None
     live_css = None
@@ -68,7 +69,7 @@ class LiveReloadHandler(WebSocketHandler):
         filepath, delay = cls.watcher.examine()
         if not filepath or delay == 'forever' or not cls.waiters:
             return
-        reload_time = 3
+        reload_time = DEFAULT_RELOAD_TIME
 
         if delay:
             reload_time = max(3 - delay, 1)


### PR DESCRIPTION
## Use case

I use the following `watch_and_serve.py` script:
```python
#!/usr/bin/env python3

from os.path import dirname
from livereload import Server
from other_module import gen_css_bundle

SERVER = Server()
SERVER.watch('index.html')
SERVER.watch('assets/css/main.css', gen_css_bundle)
SERVER.serve(root='.')
```

The `gen_css_bundle` function takes a few milliseconds to execute and **edit index.html to insert the new bundle filename**.

When I run this script and edit `main.css`, I see the following logs:
```
[I 210327 10:57:21 watcher:104] Running task: gen_css_bundle (delay: 3)
[I 210327 10:57:21 handlers:95] Reload 1 waiters: ./assets/css/main.css
[I 210327 10:57:22 handlers:82] Ignore: ./index.html
```

I want to introduce a mechanism in `livereload` in order to control this "ignore" logic,
so that in my case the brower is reloaded once `index.html` has been edited by `gen_css_bundle`.

## Suggested solution
Hence, this PR introduces a `livereload.handlers.LiveReloadHandler.DEFAULT_RELOAD_TIME` class constant,
that can be used this way:
```python
#!/usr/bin/env python3

from os.path import dirname
from livereload import Server
from livereload.handlers import LiveReloadHandler
LiveReloadHandler.DEFAULT_RELOAD_TIME = 0  # do not ignore index.html edition by gen_css_bundle and trigger browser reload
from other_module import gen_css_bundle

SERVER = Server()
SERVER.watch('index.html')
SERVER.watch('assets/css/main.css', gen_css_bundle)
SERVER.serve(root='.')
```