### PR TITLE
Fix handling of 'forever' delay (fixes #125)

### DIFF
--- a/livereload/watcher.py
+++ b/livereload/watcher.py
@@ -95,7 +95,7 @@ class Watcher:
             if changed:
                 func = item['func']
                 delay = item['delay']
-                if delay and isinstance(delay, float):
+                if delay and isinstance(delay, float) or delay == 'forever':
                     delays.add(delay)
                 if func:
                     name = getattr(func, 'name', None)
@@ -108,8 +108,10 @@ class Watcher:
                     else:
                         func()
 
-        if delays:
-            delay = max(delays)
+        if delays == {'forever'}:
+            delay = 'forever'
+        elif delays:
+            delay = max(delays - {'forever'})
         else:
             delay = None
         return self.filepath, delay

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -150,3 +150,18 @@ class TestWatcher(unittest.TestCase):
         os.remove(second_path)
         assert watcher.examine() == (second_path, None)
         assert watcher.examine() == (None, None)
+
+    def test_watch_delay_forever(self):
+        watcher = Watcher()
+
+        filepath = os.path.join(tmpdir, 'foo')
+        abs_filepath = os.path.abspath(filepath)
+
+        with open(filepath, 'w') as f:
+            f.write('')
+
+        watcher.watch(filepath, delay=1.0)
+        watcher.watch(filepath, delay='forever')
+
+        assert watcher.examine() == (abs_filepath, 'forever')
+        assert watcher.examine() == (None, None)


### PR DESCRIPTION
This PR builds on the work in #236 and avoids comparing strings and floats when computing the max delay.