### PR TITLE
Fix LiveScriptInjector so that <script> is never injected twice

### DIFF
--- a/livereload/server.py
+++ b/livereload/server.py
@@ -105,7 +105,7 @@ class LiveScriptInjector(web.OutputTransform):
 
     def transform_first_chunk(self, status_code, headers, chunk, finishing):
         if HEAD_END in chunk:
-            chunk = chunk.replace(HEAD_END, self.script + HEAD_END)
+            chunk = chunk.replace(HEAD_END, self.script + HEAD_END, 1)
             if 'Content-Length' in headers:
                 length = int(headers['Content-Length']) + len(self.script)
                 headers['Content-Length'] = str(length)


### PR DESCRIPTION
With a web page containing **tow** `<head>` sections,
the current version of `livereload` breaks with this error:
```
[E 220721 20:20:24 web:1791] Uncaught exception GET / (127.0.0.1)
    HTTPServerRequest(protocol='http', host='localhost:5500', method='GET', uri='/', version='HTTP/1.1', remote_ip='127.0.0.1'
)
    Traceback (most recent call last):
      File "/usr/local/lib/python3.8/site-packages/tornado/web.py", line 1706, in _execute
        result = await result
      File "/usr/local/lib/python3.8/site-packages/tornado/web.py", line 2650, in get
        await self.flush()
      File "/usr/local/lib/python3.8/site-packages/tornado/web.py", line 1095, in flush
        return self.request.connection.write_headers(
      File "/usr/local/lib/python3.8/site-packages/tornado/http1connection.py", line 465, in write_headers
        data += self._format_chunk(chunk)
      File "/usr/local/lib/python3.8/site-packages/tornado/http1connection.py", line 477, in _format_chunk
        raise httputil.HTTPOutputError(
    tornado.httputil.HTTPOutputError: Tried to write more data than Content-Length
```

This PR makes sure such situation never happens