### PR TITLE
Fix long_description in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     packages=['livereload', 'livereload.management.commands'],
     description='Python LiveReload is an awesome tool for web developers',
     long_description_content_type='text/x-rst',
-    long_description=fread('README.rst'),
+    long_description=fread('README.md'),
     entry_points={
         'console_scripts': [
             'livereload = livereload.cli:main',


### PR DESCRIPTION
The long description points to `README.rst`, which doesn't exist and makes `pip install .` fail.
This changes the filename to `README.md`. However, we may have to change it in `MANIFEST` as well.