### PR TITLE
Fix issue with WSGI container error

### DIFF
--- a/livereload/server.py
+++ b/livereload/server.py
@@ -125,7 +125,7 @@ class LiveScriptContainer(WSGIContainer):
             return response.append
 
         app_response = self.wsgi_app(
-            WSGIContainer.environ(request), start_response)
+            WSGIContainer(self.wsgi_app).environ(request), start_response)
         try:
             response.extend(app_response)
             body = b"".join(response)


### PR DESCRIPTION
I'm using Flask v3 and Python 3.11.  When starting up my server I got the following error ([and it seems I'm not the only one):
](https://stackoverflow.com/questions/77333325/setting-up-auto-refresh-with-flask-on-template-change)

```
    Traceback (most recent call last):
      File "/Users/john/venv/ema-cSETeqck/lib/python3.11/site-packages/tornado/web.py", line 1767, in _execute
        result = self.prepare()
                 ^^^^^^^^^^^^^^
      File "/Users/john/venv/ema-cSETeqck/lib/python3.11/site-packages/tornado/web.py", line 3149, in prepare
        self.fallback(self.request)
      File "/Users/john/venv/ema-cSETeqck/lib/python3.11/site-packages/livereload/server.py", line 135, in __call__
        app_response = self.wsgi_app(WSGIContainer.environ(request), start_response)
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    TypeError: WSGIContainer.environ() missing 1 required positional argument: 'request'
```

This fix is simple, and fixes the issue on my system.  
