### PR TITLE
feat: support python -m livereload invocation

### DIFF
--- a/livereload/__main__.py
+++ b/livereload/__main__.py
@@ -1,0 +1,3 @@
+from livereload.cli import main
+
+main()


### PR DESCRIPTION
## Summary

Adds `livereload/__main__.py` so the development server can be started with:

```bash
python -m livereload [directory]
```

This mirrors the familiar pattern established by `python -m http.server` from the standard library, which many developers already reach for when they need a quick local server.

The implementation delegates directly to the existing `cli.main()` entry point — no behaviour changes, no new arguments, no new dependencies. The `__main__.py` is three lines.

## Before / After

**Before:**
```bash
# Required a one-liner or a dedicated script
python -c "from livereload import Server; Server().serve(root='.')"
```

**After:**
```bash
python -m livereload
python -m livereload ./docs
python -m livereload --port 8080 ./site
```

## Test plan

- [ ] `python -m livereload --help` shows the existing CLI help
- [ ] `python -m livereload .` serves the current directory with live reload
- [ ] `python -m livereload ./subdir` serves a subdirectory correctly
- [ ] All existing CLI flags (`--host`, `--port`, `--target`, etc.) work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)